### PR TITLE
Update actions/setup-java to v2.x & JDK upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
+        distribution: adopt
         java-version: 11
 
     - name: Cache Coursier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 8
+        java-version: 11
 
     - name: Cache Coursier
       uses: coursier/cache-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
 
     - name: Cache Coursier
       uses: coursier/cache-action@v5

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: 8
 
       - name: Cache Coursier
         uses: coursier/cache-action@v5

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
+          distribution: adopt
           java-version: 11
 
       - name: Cache Coursier

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Cache Coursier
         uses: coursier/cache-action@v5


### PR DESCRIPTION
- Update actions/setup-java to 2.x
- Update JDK to 11
- Use AdoptOpenJDK instead